### PR TITLE
Add Google Colab notebook for Freqtrade bot workflow

### DIFF
--- a/freqtrade_colab.ipynb
+++ b/freqtrade_colab.ipynb
@@ -1,0 +1,259 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Freqtrade in Google Colab\n",
+        "\n",
+        "Dieses Notebook richtet eine voll funktionsf\u00e4hige Freqtrade-Umgebung in Google Colab ein und zeigt Schritt f\u00fcr Schritt, wie du den Bot f\u00fcr Backtests, Optimierungen und den Paper-Trading-Betrieb verwendest."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 1. Umgebung initialisieren\n",
+        "\n",
+        "F\u00fchre die folgende Zelle aus, um alle Abh\u00e4ngigkeiten zu installieren und die Freqtrade-Verzeichnisstruktur anzulegen."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "%%bash\n",
+        "set -e\n",
+        "python -m pip install --quiet --upgrade pip\n",
+        "python -m pip install --quiet \"freqtrade==2024.6\" \"ccxt>=4.0.0\" plotly taipy\n",
+        "freqtrade create-userdir --userdir /content/freqtrade\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 2. Optional: Google Drive einbinden\n",
+        "\n",
+        "Wenn du Konfigurationen oder Ergebnisse dauerhaft speichern m\u00f6chtest, mounte deinen Google Drive und verschiebe das Arbeitsverzeichnis nach `/content/drive/MyDrive`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "from google.colab import drive\n",
+        "from pathlib import Path\n",
+        "\n",
+        "drive.mount('/content/drive')\n",
+        "base_path = Path('/content/drive/MyDrive/freqtrade')\n",
+        "base_path.mkdir(parents=True, exist_ok=True)\n",
+        "!rm -rf /content/freqtrade\n",
+        "!ln -s $base_path /content/freqtrade\n",
+        "print('Arbeitsverzeichnis:', base_path)\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 3. Konfiguration und Beispiel-Strategie\n",
+        "\n",
+        "Die n\u00e4chste Zelle erzeugt eine minimalistische Beispiel-Strategie sowie eine Konfigurationsdatei mit sinnvollen Standardeinstellungen f\u00fcr Backtests und Paper-Trading."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "from pathlib import Path\n",
+        "import json\n",
+        "\n",
+        "userdir = Path('/content/freqtrade')\n",
+        "(userdir / 'user_data/strategies').mkdir(parents=True, exist_ok=True)\n",
+        "\n",
+        "strategy = '''\n",
+        "from freqtrade.strategy import IStrategy\n",
+        "from pandas import DataFrame\n",
+        "\n",
+        "class ColabExampleStrategy(IStrategy):\n",
+        "    timeframe = '1h'\n",
+        "    startup_candle_count = 50\n",
+        "    minimal_roi = {\"0\": 0.04, \"120\": 0.02, \"240\": 0.01, \"720\": 0}\n",
+        "    stoploss = -0.1\n",
+        "\n",
+        "    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:\n",
+        "        dataframe['ema_short'] = dataframe['close'].ewm(span=12).mean()\n",
+        "        dataframe['ema_long'] = dataframe['close'].ewm(span=26).mean()\n",
+        "        return dataframe\n",
+        "\n",
+        "    def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:\n",
+        "        dataframe.loc[\n",
+        "            (dataframe['ema_short'] > dataframe['ema_long']) &\n",
+        "            (dataframe['volume'] > 0),\n",
+        "            'enter_long'\n",
+        "        ] = 1\n",
+        "        return dataframe\n",
+        "\n",
+        "    def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:\n",
+        "        dataframe.loc[\n",
+        "            (dataframe['ema_short'] < dataframe['ema_long']),\n",
+        "            'exit_long'\n",
+        "        ] = 1\n",
+        "        return dataframe\n",
+        "'''\n",
+        "\n",
+        "(userdir / 'user_data/strategies/ColabExampleStrategy.py').write_text(strategy)\n",
+        "\n",
+        "config = {\n",
+        "    \"user_data_dir\": str(userdir),\n",
+        "    \"dataformat_ohlcv\": \"json\",\n",
+        "    \"dry_run\": True,\n",
+        "    \"dry_run_wallet\": 1000,\n",
+        "    \"stake_currency\": \"USDT\",\n",
+        "    \"stake_amount\": \"unlimited\",\n",
+        "    \"exchange\": {\n",
+        "        \"name\": \"binance\",\n",
+        "        \"key\": \"\",\n",
+        "        \"secret\": \"\",\n",
+        "        \"ccxt_config\": {},\n",
+        "        \"pair_whitelist\": [\"BTC/USDT\", \"ETH/USDT\", \"SOL/USDT\"],\n",
+        "        \"pair_blacklist\": []\n",
+        "    },\n",
+        "    \"timeframe\": \"1h\",\n",
+        "    \"max_open_trades\": 3,\n",
+        "    \"tradable_balance_ratio\": 0.99,\n",
+        "    \"stoploss\": -0.1,\n",
+        "    \"strategy\": \"ColabExampleStrategy\",\n",
+        "    \"forcebuy_enable\": True,\n",
+        "    \"timeframe_detail\": \"5m\",\n",
+        "    \"telegram\": {\n",
+        "        \"enabled\": False\n",
+        "    },\n",
+        "    \"api_server\": {\n",
+        "        \"enabled\": False,\n",
+        "        \"listen_ip_address\": \"0.0.0.0\",\n",
+        "        \"listen_port\": 8080,\n",
+        "        \"verbosity\": \"info\",\n",
+        "        \"jwt_secret_key\": \"changeme\",\n",
+        "        \"CORS_origins\": []\n",
+        "    }\n",
+        "}\n",
+        "\n",
+        "(userdir / 'user_data/config.json').write_text(json.dumps(config, indent=4))\n",
+        "print('Strategie und Konfigurationsdatei wurden erstellt.')\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 4. Marktdaten herunterladen\n",
+        "\n",
+        "Lade historische Daten \u00fcber die integrierte Download-Funktion. W\u00e4hle dazu Exchange, Paar(e) und Zeitrahmen passend zu deiner Strategie."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!freqtrade download-data     --userdir /content/freqtrade     --exchange binance     --timeframes 1h 5m     --days 30     --pairs BTC/USDT ETH/USDT SOL/USDT\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 5. Backtesting\n",
+        "\n",
+        "Mit der folgenden Zelle f\u00fchrst du einen Backtest gegen die heruntergeladenen Daten aus und erh\u00e4ltst eine Zusammenfassung der Performance."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!freqtrade backtesting     --userdir /content/freqtrade     --config /content/freqtrade/user_data/config.json     --strategy ColabExampleStrategy     --timeframe 1h\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 6. Hyperparameter-Optimierung (Hyperopt)\n",
+        "\n",
+        "Nutze Hyperopt, um Strategie-Parameter automatisch zu optimieren. Passe `--spaces` und die Anzahl der Epochen an deine Bed\u00fcrfnisse an."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!freqtrade hyperopt     --userdir /content/freqtrade     --config /content/freqtrade/user_data/config.json     --strategy ColabExampleStrategy     --hyperopt-loss SharpeHyperOptLossDaily     --spaces buy sell roi stoploss     --epochs 100\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 7. Paper-Trading / Dry-Run starten\n",
+        "\n",
+        "Aktiviere den Bot im Dry-Run-Modus, um Trades ohne echtes Kapital zu simulieren. In Colab empfiehlt sich die Verwendung eines separaten Tabs oder `tmux` via `colab_ssh`, damit der Prozess dauerhaft laufen kann."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!freqtrade trade     --userdir /content/freqtrade     --config /content/freqtrade/user_data/config.json     --strategy ColabExampleStrategy     --dry-run\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 8. N\u00fctzliche Tipps\n",
+        "\n",
+        "- Passe die `pair_whitelist` und `timeframe` an dein Portfolio und deinen Handelsstil an.\n",
+        "- Nutze das `freqtrade plot-dataframe` Kommando, um Candle-Charts inklusive Indikatoren zu visualisieren.\n",
+        "- Speichere Ergebnisse (Backtests, Hyperopt-Resultate) in Google Drive, um sie au\u00dferhalb der aktuellen Session verf\u00fcgbar zu machen.\n",
+        "- Verwende `freqtrade list-pairs` oder `freqtrade list-timeframes`, um unterst\u00fctzte M\u00e4rkte und Zeitfenster deines Exchanges zu pr\u00fcfen."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Google Colab notebook that installs and configures Freqtrade in a Colab runtime
- provide cells for creating a sample strategy, downloading market data, running backtests, hyperopt, and dry-run trading

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e5724937a883208c1dd66d25b7ef05